### PR TITLE
Fix SDL event initialization and backend context allocation

### DIFF
--- a/src/backends/sdl2_renderer.cpp
+++ b/src/backends/sdl2_renderer.cpp
@@ -279,7 +279,7 @@ ret_code Renderer::initScreen(Context &ctx, int32_t x, int32_t y, int32_t w, int
         return ErrorCode;
     }
 
-    ctx.mBackendCtx = new BackendContext;.
+    ctx.mBackendCtx = new BackendContext;
     ctx.mBackendCtx->mHandle = (void*) sdlCtx;
 
     if (TTF_Init() == -1) {

--- a/src/backends/sdl2_renderer.cpp
+++ b/src/backends/sdl2_renderer.cpp
@@ -279,7 +279,7 @@ ret_code Renderer::initScreen(Context &ctx, int32_t x, int32_t y, int32_t w, int
         return ErrorCode;
     }
 
-    ctx.mBackendCtx = new BackendContext;
+    ctx.mBackendCtx = new BackendContext;.
     ctx.mBackendCtx->mHandle = (void*) sdlCtx;
 
     if (TTF_Init() == -1) {
@@ -454,7 +454,7 @@ bool Renderer::update(const Context &ctx) {
     }
 
     bool running = !ctx.mRequestShutdown;
-    SDL_Event event = {};
+    SDL_Event event;
     while (IODevice::update(event)) {
         switch (event.type) {
             case SDL_QUIT:


### PR DESCRIPTION
- This initialization is based on an union and will cause undefined behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved renderer event handling to reduce rare event-processing issues and enhance runtime stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->