### PR TITLE
ENable autodeploy of assets into bin folder

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,8 +76,8 @@ if( TINY_UI_SAMPLES)
     add_custom_target(tiny_ui_copy_assets ALL
         COMMAND ${CMAKE_COMMAND} -E copy_directory
                 ${CMAKE_CURRENT_SOURCE_DIR}/assets
-                ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/assets
-        COMMENT "Copying assets to ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/assets"
+                ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/$<CONFIG>)
+        COMMENT "Copying assets to ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/$<CONFIG>)"
     )
     add_dependencies(tiny_ui_sample tiny_ui_copy_assets)
     add_dependencies(tiny_ui_hello_world tiny_ui_copy_assets)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,8 +76,8 @@ if( TINY_UI_SAMPLES)
     add_custom_target(tiny_ui_copy_assets ALL
         COMMAND ${CMAKE_COMMAND} -E copy_directory
                 ${CMAKE_CURRENT_SOURCE_DIR}/assets
-                ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/$<CONFIG>)
-        COMMENT "Copying assets to ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/$<CONFIG>)"
+                ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/$<CONFIG>
+        COMMENT "Copying assets to ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/$<CONFIG>"
     )
     add_dependencies(tiny_ui_sample tiny_ui_copy_assets)
     add_dependencies(tiny_ui_hello_world tiny_ui_copy_assets)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,15 @@ if( TINY_UI_SAMPLES)
         $<IF:$<TARGET_EXISTS:SDL2_ttf::SDL2_ttf>,SDL2_ttf::SDL2_ttf,SDL2_ttf::SDL2_ttf-static>
     )
 
+    add_custom_target(tiny_ui_copy_assets ALL
+        COMMAND ${CMAKE_COMMAND} -E copy_directory
+                ${CMAKE_CURRENT_SOURCE_DIR}/assets
+                ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/assets
+        COMMENT "Copying assets to ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/assets"
+    )
+    add_dependencies(tiny_ui_sample tiny_ui_copy_assets)
+    add_dependencies(tiny_ui_hello_world tiny_ui_copy_assets)
+
 endif()
 
 # Include tests if they exist

--- a/samples/demo/main.cpp
+++ b/samples/demo/main.cpp
@@ -97,7 +97,7 @@ int main(int argc, char *argv[]) {
     
     Widgets::checkBox(panel, "Check me", Rect(100, 200, 100, ButtonHeight), false, nullptr);
 
-    Widgets::imageButton(panel, "button_test.png", Rect(100, 250, 100, ButtonHeight), nullptr);
+    Widgets::imageButton(panel, "images/button_test.png", Rect(100, 250, 100, ButtonHeight), nullptr);
 
     auto &ctx = TinyUi::getContext();
 

--- a/src/backends/sdl2_iodevice.h
+++ b/src/backends/sdl2_iodevice.h
@@ -31,6 +31,15 @@ namespace tinyui {
 ///
 /// IO-Devices are used to contrl any kind of input / output operations.
 struct IODevice {
+    // No copying or moving allowed.
+    IODevice(const IODevice &) = delete;
+    IODevice(IODevice &&) = delete;
+    IODevice &operator=(const IODevice &) = delete;
+    IODevice &operator=(IODevice &&) = delete;
+
+    /// @brief Default constructor.
+    IODevice() = default;
+
     /// @brief Default destructor.
     ~IODevice() = default;
 

--- a/src/backends/sdl2_renderer.cpp
+++ b/src/backends/sdl2_renderer.cpp
@@ -36,7 +36,8 @@ namespace {
         ctx.mDefaultFont = new Font;
         ctx.mDefaultFont->mFont = new FontImpl;
         ctx.mDefaultFont->mSize = ctx.mStyle.mFont.mSize;
-        ctx.mDefaultFont->mFont->mFontImpl = TTF_OpenFont(ctx.mStyle.mFont.mName, ctx.mStyle.mFont.mSize);
+        std::string fontName = "fonts/" + std::string(ctx.mStyle.mFont.mName);
+        ctx.mDefaultFont->mFont->mFontImpl = TTF_OpenFont(fontName.c_str(), ctx.mStyle.mFont.mSize);
     }
 
     Font *loadDefaultFont(Context &ctx) {

--- a/src/backends/sdl2_renderer.h
+++ b/src/backends/sdl2_renderer.h
@@ -108,7 +108,20 @@ inline SDLContext *getBackendContext(Context &ctx) {
 
 /// @brief The renderer implementation using the SDL2 library.
 struct Renderer {
-    static ret_code initRenderer(Context &ctx);
+    // No copying or moving allowed.
+    Renderer(const Renderer &) = delete;
+    Renderer(Renderer &&) = delete;
+    Renderer &operator=(const Renderer &) = delete;
+    Renderer &operator=(Renderer &&) = delete;
+
+    /// @brief Default constructor.
+    Renderer() = default;
+
+    /// @brief Default destructor.
+    ~Renderer() = default;
+
+    // Render implementation functions. 
+    static ret_code initRenderer(Context &ctx);    
     static ret_code releaseRenderer(Context &ctx);
     static ret_code initScreen(Context &ctx, int32_t x, int32_t y, int32_t w, int32_t h);
     static ret_code initScreen(Context &ctx, SDL_Window *mWindow, SDL_Renderer *mRenderer);

--- a/src/widgets.cpp
+++ b/src/widgets.cpp
@@ -129,7 +129,6 @@ namespace {
         if (!parent->mRect.isInited()) {
             parent->mRect = child->mRect;
         }
-        //parent->mRect.mergeWithRect(child->mRect);
 
         return parent;
     }
@@ -150,6 +149,14 @@ namespace {
     }
 
     void deleteKeyFromText(Context &ctx) {
+        if (ctx.mFocus == nullptr) {
+            return;
+        }
+        
+        if (ctx.mFocus->mText.empty()) {
+            return;
+        }
+
         ctx.mFocus->mText.erase(ctx.mFocus->mText.size() - 1);
     }
 
@@ -443,9 +450,6 @@ WidgetHandle Widgets::treeView(WidgetHandle parentId, const char *title, const R
 
     auto *callback = new CallbackI(onTreeViewItemClicked, nullptr, Events::MouseButtonDownEvent);
     widget->mCallback = callback;
-    /* if (callback != nullptr) {
-        callback->incRef();
-    }*/
 
     return widget->mHandle;
 }


### PR DESCRIPTION
- closes https://github.com/kimkulling/tiny_ui/issues/61

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * UI sample assets are now copied to the configuration-specific runtime output directory, ensuring they are available when running builds across different configurations.
  * Demo buttons now load images from the correct `images/` directory.
  * Configured fonts now load from the bundled fonts directory.
  * Deleting text no longer affects widgets without focus or already-empty text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->